### PR TITLE
Made "Hehe" message clientside

### DIFF
--- a/Common/src/main/java/io/github/sirjain0/perfectplushies/block/PlushieBlock.java
+++ b/Common/src/main/java/io/github/sirjain0/perfectplushies/block/PlushieBlock.java
@@ -60,24 +60,14 @@ public class PlushieBlock extends HorizontalDirectionalBlock {
 
     // Handles plushie's chat message and displays particles on right click
 
-    @Override
-    public InteractionResult use(BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand, BlockHitResult blockHitResult) {
-        if(!level.isClientSide){
-            RandomSource randomNum = level.random;
-
-            if (randomNum.nextInt(2) == 1) {
-                MinecraftServer server = level.getServer();
-                if (server == null) return InteractionResult.PASS;
-
-                List<ServerPlayer> serverList = server.getPlayerList().getPlayers();
-
-                for (ServerPlayer serverPlayer : serverList) {
-                    serverPlayer.sendSystemMessage(Component.literal("[Plushie] ").withStyle(ChatFormatting.GRAY, ChatFormatting.BOLD).append("Hehe!"));
-                }
-            }
-        } else {
-            level.addParticle(ParticleTypes.HEART, pos.getX() + (level.random.nextInt(2)), pos.getY(), pos.getZ() + (level.random.nextInt(2)), 0, 0, 0);
-        }
-        return InteractionResult.SUCCESS;
+  public InteractionResult use(BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand, BlockHitResult blockHitResult) {
+    if (level.isClientSide) {
+      RandomSource randomNum = level.random;
+      if (randomNum.nextInt(2) == 1) {
+        player.sendSystemMessage(Component.literal("[Plushie] ").withStyle(ChatFormatting.GRAY, ChatFormatting.BOLD).append("Hehe!"));
+      }
+      level.addParticle(ParticleTypes.HEART, pos.getX() + (level.random.nextInt(2)), pos.getY(), pos.getZ() + (level.random.nextInt(2)), 0, 0, 0);
     }
+    return InteractionResult.SUCCESS;
+  }
 }


### PR DESCRIPTION
Your mod was recently added to the following modpack: https://www.curseforge.com/minecraft/modpacks/darkrpg
Whenever anyone right clicked a plush, the entire server would receive the "Hehe!" message. This PR makes that message client side rather than playing to all players.

Sidenote - I wasn't able to build the jar, so please check that the PR works on a server environment and only plays to the player who interacted with the plush, before merging.